### PR TITLE
Blog app: add authorization rules

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,4 +76,8 @@ group :test do
   gem 'webdrivers'
 end
 
+# Authentication library
 gem 'devise', '~> 4.9'
+
+# Authorization library Cancancan
+gem 'cancancan'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    cancancan (3.5.0)
     capybara (3.39.2)
       addressable
       matrix
@@ -270,6 +271,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  cancancan
   capybara
   debug
   devise (~> 4.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.3-x64-mingw-ucrt)
+      racc (~> 1.4)
     nokogiri (1.15.3-x86_64-darwin)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -145,6 +147,7 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.3)
+    pg (1.5.3-x64-mingw-ucrt)
     public_suffix (5.0.3)
     puma (5.6.6)
       nio4r (~> 2.0)
@@ -246,6 +249,8 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2023.3)
+      tzinfo (>= 1.0.0)
     unicode-display_width (2.4.2)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -267,6 +272,7 @@ GEM
     zeitwerk (2.6.8)
 
 PLATFORMS
+  x64-mingw-ucrt
   x86_64-darwin-22
 
 DEPENDENCIES

--- a/app/assets/stylesheets/comment.css
+++ b/app/assets/stylesheets/comment.css
@@ -1,0 +1,9 @@
+.comment-details {
+  display: flex;
+  justify-content: space-between;
+  padding-block: 3px;
+}
+
+.comment-divider {
+  border-bottom: 0.5px solid #ccc;
+}

--- a/app/assets/stylesheets/user-details.css
+++ b/app/assets/stylesheets/user-details.css
@@ -39,12 +39,18 @@ p.post-text {
 
 span.post-author {
   font-size: 18px;
-  padding-block-start: 20px;
 }
 
-p.likes-and-comments-count {
-  text-align: right;
+.likes-and-comments-count {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 5px;
   padding-inline: 10px;
+}
+
+.likes-and-comments-count form {
+  display: flex;
 }
 
 form.show-posts {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  rescue_from CanCan::AccessDenied do | exception |
+  rescue_from CanCan::AccessDenied do |exception|
     redirect_to root_url, alert: exception.message
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def update_allowed_parameters
-    devise_parameter_sanitizer.permit(:sign_up) { |u| u.permit(:name, :surname, :email, :password) }
+    devise_parameter_sanitizer.permit(:sign_up) { |u| u.permit(:name, :surname, :email, :password, :role) }
     devise_parameter_sanitizer.permit(:account_update) do |u|
       u.permit(:name, :surname, :email, :password, :current_password)
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,4 +11,8 @@ class ApplicationController < ActionController::Base
       u.permit(:name, :surname, :email, :password, :current_password)
     end
   end
+
+  rescue_from CanCan::AccessDenied do | exception |
+    redirect_to root_url, alert: exception.message
+  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -82,4 +82,19 @@ class PostsController < ApplicationController
       end
     end
   end
+
+  def delete_post
+    post = Post.find(params[:id])
+    respond_to do |format|
+      format.html do
+        if post.destroy
+          flash[:success] = 'Post deleted'
+          redirect_to "/users/#{params[:user_id]}/posts/"
+        else
+          flash.now[:error] = 'Error: Delete unsuccesful'
+          redirect_to "/users/#{params[:user_id]}/posts/#{params[:id]}/", locals: { post: }
+        end
+      end
+    end
+  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -97,4 +97,20 @@ class PostsController < ApplicationController
       end
     end
   end
+
+  def delete_comment
+    comment = Comment.find(params[:comment_id])
+    post = Post.find(comment.post_id)
+    respond_to do |format|
+      format.html do
+        if comment.destroy
+          flash[:success] = 'Comment deleted'
+          redirect_to "/users/#{params[:user_id]}/posts/#{params[:id]}/", locals: { post: }
+        else
+          flash.now[:error] = 'Error: Delete unsuccesful'
+          redirect_to "/users/#{params[:user_id]}/posts/#{params[:id]}/", locals: { post: }
+        end
+      end
+    end
+  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -105,11 +105,10 @@ class PostsController < ApplicationController
       format.html do
         if comment.destroy
           flash[:success] = 'Comment deleted'
-          redirect_to "/users/#{params[:user_id]}/posts/#{params[:id]}/", locals: { post: }
         else
           flash.now[:error] = 'Error: Delete unsuccesful'
-          redirect_to "/users/#{params[:user_id]}/posts/#{params[:id]}/", locals: { post: }
         end
+        redirect_to "/users/#{params[:user_id]}/posts/#{params[:id]}/", locals: { post: }
       end
     end
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,42 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # Define abilities for the user here. For example:
+    #
+    # Handle the case where we don't have a current_user i.e. the user is a guest
+    user ||= User.new
+
+    can :read, Post, public: true
+    can :read, Comment, public: true
+    can :read, Like, public: true
+
+    return unless user.present?  # additional permissions for logged in users (they can read their own posts)
+    can :manage, Post, author: user
+    can :manage, Comment, author: user
+    can :create, Like, author: user
+
+    return unless user.is?(:admin)  # additional permissions for administrators
+    can :manage, Post, user: user
+    can :manage, Comment, user: user
+    can :create, Like, user: user
+
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, published: true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/blob/develop/docs/define_check_abilities.md
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -17,9 +17,9 @@ class Ability
     can :create, Like, author: user
 
     return unless user.is?(:admin)  # additional permissions for administrators
-    can :manage, Post, user: user
-    can :manage, Comment, user: user
-    can :create, Like, user: user
+    can :manage, Post, author: user
+    can :manage, Comment, author: user
+    can :create, Like, author: user
 
     # The first argument to `can` is the action you are giving the user
     # permission to do.

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -7,19 +7,19 @@ class Ability
     # Handle the case where we don't have a current_user i.e. the user is a guest
     user ||= User.new
 
-    can :read, Post, public: true
-    can :read, Comment, public: true
-    can :read, Like, public: true
+    can :read, Post
+    can :read, Comment
+    can :read, Like
 
     return unless user.present?  # additional permissions for logged in users (they can read their own posts)
     can :manage, Post, author: user
     can :manage, Comment, author: user
-    can :create, Like, author: user
+    can :manage, Like
 
-    return unless user.is?(:admin)  # additional permissions for administrators
-    can :manage, Post, author: user
-    can :manage, Comment, author: user
-    can :create, Like, author: user
+    return unless user.admin? # additional permissions for administrators
+    can :manage, Post
+    can :manage, Comment
+    can :manage, Like
 
     # The first argument to `can` is the action you are giving the user
     # permission to do.

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -11,12 +11,14 @@ class Ability
     can :read, Comment
     can :read, Like
 
-    return unless user.present?  # additional permissions for logged in users (they can read their own posts)
+    return unless user.present? # additional permissions for logged in users (they can read their own posts)
+
     can :manage, Post, author: user
     can :manage, Comment, author: user
     can :manage, Like
 
     return unless user.admin? # additional permissions for administrators
+
     can :manage, Post
     can :manage, Comment
     can :manage, Like

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,6 +3,7 @@ class Comment < ApplicationRecord
   belongs_to :author, class_name: 'User'
 
   after_save :update_comments_counter
+  after_destroy :update_comments_counter
   def update_comments_counter
     post.update(comments_counter: post.comments.count)
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,8 +1,8 @@
 class Post < ApplicationRecord
   # belongs_to :author, counter_cache: :posts_counter, class_name: 'User'
   belongs_to :author, class_name: 'User'
-  has_many :likes, foreign_key: :post_id
-  has_many :comments, foreign_key: :post_id
+  has_many :likes, foreign_key: :post_id, dependent: :destroy
+  has_many :comments, foreign_key: :post_id, dependent: :destroy
 
   # validations
   validates :title, presence: true, length: { maximum: 250 }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,6 +10,7 @@ class Post < ApplicationRecord
   validates :comments_counter, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   after_save :post_counter_update
+  after_destroy :post_counter_update
   def post_counter_update
     author.update(posts_counter: author.posts.count)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,8 +6,8 @@ class User < ApplicationRecord
 
   ROLES = %i[admin default].freeze
 
-  def is?(requested_role)
-    role == requested_role.to_s
+  def admin?
+    role == "admin"
   end
 
   has_many :posts, foreign_key: :author_id, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   ROLES = %i[admin default].freeze
 
   def admin?
-    role == "admin"
+    role == 'admin'
   end
 
   has_many :posts, foreign_key: :author_id, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,12 +3,20 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
-  has_many :posts, foreign_key: :author_id
-  has_many :likes, foreign_key: :author_id
-  has_many :comments, foreign_key: :author_id
-  has_many :liked_posts, through: :likes, source: :post
-  has_many :commented_posts, through: :comments, source: :post
+
+  ROLES = %i[admin default].freeze
+
+  def is?(requested_role)
+    role == requested_role.to_s
+  end
+
+  has_many :posts, foreign_key: :author_id, dependent: :destroy
+  has_many :likes, foreign_key: :author_id, dependent: :destroy
+  has_many :comments, foreign_key: :author_id, dependent: :destroy
+  has_many :liked_posts, through: :likes, source: :post, dependent: :destroy
+  has_many :commented_posts, through: :comments, source: :post, dependent: :destroy
   attribute :posts_counter, :integer, default: 0
+  attribute :role, :string, default: 'default'
   attribute :photo, :string, default: 'https://www.nicepng.com/png/detail/806-8061298_jacques-mestre-generic-male-profile.png'
 
   validates :name, presence: true

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -27,6 +27,10 @@
       <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: 'Confirm Password' %>
     </div>
 
+    <div class="field">
+        <%= f.collection_select(:role, User::ROLES, :to_s, lambda{|i| i.to_s.humanize}) %>
+    </div>
+
     <div class="actions">
       <%= f.submit "Sign up" %>
     </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -30,8 +30,5 @@
     </div>
     <% end %>
   </section>
-
-
-
   <br>
 </main>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -26,7 +26,7 @@
       <%end%>
     </div>
     <span class='post-author'>
-      <p><strong>Author:</strong> <%= @user.name%></p>
+      <p><strong>Author:</strong> <%= @user.name%>&nbsp;<%= @user.surname%></p>
     </span>
   </div>
   <% if flash[:success] %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -6,13 +6,25 @@
   <div class='post-container'>
     <div class='post-header'>
       <h3 class='post-title'><%= @post.title %> (Post #<%= @post.id %>)</h3>
-      <span class='likes-and-comments'>
-        Comments: <%= @post.comments_counter %>, Likes: <%= @post.likes_counter %>
-      </span>
     </div>
     <p class='post-text'>
       <%= @post.text %>
     </p>
+    <div class='likes-and-comments-count'>
+      Comments: <%= @post.comments_counter %>,&nbsp;
+      Likes: <%= @post.likes_counter %>,&nbsp;
+      <form class='show-posts' action="/users/<%=params[:user_id]%>/posts/<%=params[:id]%>/new_comment">
+        <input type='Submit' value='Add comment'>
+      </form>
+      <form class='show-posts left-margin' action="/users/<%=params[:user_id]%>/posts/<%=params[:id]%>/add_like" method="post">
+        <input type='Submit' value='Like!'>
+      </form>
+      <% if can? :destroy, @post%>
+        <form class='show-posts left-margin' action="/users/<%=params[:user_id]%>/posts/<%=params[:id]%>/delete_post" method="post">
+          <input type='Submit' value='Delete'>
+        </form>
+      <%end%>
+    </div>
     <span class='post-author'>
       <p><strong>Author:</strong> <%= @user.name%></p>
     </span>

--- a/app/views/shared/_comment-container.erb
+++ b/app/views/shared/_comment-container.erb
@@ -1,4 +1,7 @@
 <div class='comment-container'>
-  <%= user.name%>: <%= comment.text %>
+  <div class='comment-details'>
+    <%= user.name%> <%= user.surname%>: <%= comment.text %>
+  </div>
+  <div class='comment-divider'></div>
 </div>
 

--- a/app/views/shared/_comment-container.erb
+++ b/app/views/shared/_comment-container.erb
@@ -1,6 +1,11 @@
 <div class='comment-container'>
   <div class='comment-details'>
     <%= user.name%> <%= user.surname%>: <%= comment.text %>
+    <% if can? :destroy, comment%>
+    <form action="/users/<%=params[:user_id]%>/posts/<%=comment.post_id%>/<%=comment.id%>/delete_comment" method='post'>
+      <input type='Submit' value='Delete'>
+    </form>
+    <% end %>
   </div>
   <div class='comment-divider'></div>
 </div>

--- a/app/views/shared/_post-container.erb
+++ b/app/views/shared/_post-container.erb
@@ -5,7 +5,7 @@
     <form class='show-posts' action="/users/<%=user.id%>/posts/<%=post.id%>">
       <input id="post-<%= post.id%>" type='Submit' value='Show Post'>
     </form>
-    <p class='likes-and-comments-count'>
+    <div class='likes-and-comments-count'>
       Comments: <%= post.comments_counter %>,&nbsp;
       Likes: <%= post.likes_counter %>,&nbsp;
       <form class='show-posts' action="/users/<%=user.id%>/posts/<%=post.id%>/new_comment">
@@ -14,6 +14,11 @@
       <form class='show-posts left-margin' action="/users/<%=user.id%>/posts/<%=post.id%>/add_like" method="post">
         <input type='Submit' value='Like!'>
       </form>
-    </p>
+      <% if can? :destroy, post%>
+        <form class='show-posts left-margin' action="/users/<%=user.id%>/posts/<%=post.id%>/delete_post" method="post">
+          <input type='Submit' value='Delete'>
+        </form>
+      <%end%>
+    </div>
   </div>
 </div>

--- a/app/views/shared/_user-container.erb
+++ b/app/views/shared/_user-container.erb
@@ -2,7 +2,7 @@
   <img class='user-image' src='<%= user.photo %>'>
   <div class='user-details'>
     <span class='user-name'>
-      <%= user.name %>
+      <%= user.name %>&nbsp;<%= user.surname%>
     </span>
     <div class='user-alt-text'>
       <% if current_page?('/users/') || current_page?('/') %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   post "/users/:user_id/posts/:id/create_comment", to: "posts#create_comment", as: 'create_comment'
   post "/users/:user_id/posts/:id/add_like", to: "posts#add_like", as: 'add_like'
   post "/users/:user_id/posts/:id/delete_post", to: "posts#delete_post", as: 'delete_poste'
+  post "/users/:user_id/posts/:id/:comment_id/delete_comment", to: "posts#delete_comment", as: 'delete_comment'
   get "/users", to: "users#index"
   get "/users/:id", to: "users#show"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   get "/users/:user_id/posts/:id/new_comment", to: "posts#new_comment", as: 'new_comment'
   post "/users/:user_id/posts/:id/create_comment", to: "posts#create_comment", as: 'create_comment'
   post "/users/:user_id/posts/:id/add_like", to: "posts#add_like", as: 'add_like'
+  post "/users/:user_id/posts/:id/delete_post", to: "posts#delete_post", as: 'delete_poste'
   get "/users", to: "users#index"
   get "/users/:id", to: "users#show"
 

--- a/db/migrate/20230727120421_add_roles_to_users.rb
+++ b/db/migrate/20230727120421_add_roles_to_users.rb
@@ -1,0 +1,5 @@
+class AddRolesToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :role, :string
+  end
+end

--- a/db/migrate/20230727120421_add_roles_to_users.rb
+++ b/db/migrate/20230727120421_add_roles_to_users.rb
@@ -1,5 +1,0 @@
-class AddRolesToUsers < ActiveRecord::Migration[7.0]
-  def change
-    add_column :users, :role, :string
-  end
-end

--- a/db/migrate/20230727165048_add_role_to_user.rb
+++ b/db/migrate/20230727165048_add_role_to_user.rb
@@ -1,0 +1,5 @@
+class AddRoleToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :role, :string, default: 'default'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_27_120421) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_27_165048) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -63,7 +63,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_120421) do
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
     t.string "surname"
-    t.string "role"
+    t.string "role", default: "default"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_26_132156) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_27_120421) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -63,6 +63,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_26_132156) do
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
     t.string "surname"
+    t.string "role"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
Blog app: add authorization rules
--
In this request majorly:

- [x] Added Installation for CanCanCan in project.
- [x] Added a role column to the users table using a migration.
- [x] Added delete functionality for posts. Admins can delete all posts.
- [x] Used CanCanCan library for authorization.
- [x] Added the "Delete" button to the posts view and the button is only visible for authorized users.
- [x] Added a comment delete functionality. User can only delete a comment if it is theirs or if they have an admin role.
- [x] Added the "Delete" button to the view and make sure that only authorized users can see it.
- [x] Added user role selection to sign-up page
- [x] Added the comment and post counter update after deletion
